### PR TITLE
Open product detail pages in new tab; remove top back-links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+node_modules/

--- a/brevn-essay/index.html
+++ b/brevn-essay/index.html
@@ -219,8 +219,6 @@
     <p class="footer-meta">Brevn is in TestFlight beta now. The App Store version follows in a few weeks.</p>
 
     <p class="footer-meta">If you build in a related direction — honest instrumentation, n=1 quantified self, sleep, attention, anything in this neighborhood — I'd genuinely like to hear from you. <a href="https://x.com/Hyperfocusedeng">@Hyperfocusedeng</a> on X, or <a href="https://hyperfocusedengineer.github.io">hyperfocusedengineer.github.io</a>.</p>
-
-    <a href="/" class="home-link">← Hyperfocused Engineer</a>
   </article>
 </body>
 </html>

--- a/brevn/index.html
+++ b/brevn/index.html
@@ -294,7 +294,6 @@
 </head>
 <body>
   <div class="container">
-    <a href="https://hyperfocusedengineer.github.io/" class="back-link">← hyperfocused engineer</a>
 
     <!-- HERO -->
     <header class="hero">

--- a/broadside/index.html
+++ b/broadside/index.html
@@ -1052,7 +1052,6 @@
 
     <!-- ─── HEADER ─── -->
     <header class="header">
-      <a href="../" class="back-link">&larr; Hyperfocused Engineer</a>
 
       <div class="seal-container">
         <div class="wax-seal">

--- a/cortis/index.html
+++ b/cortis/index.html
@@ -543,7 +543,6 @@
 </head>
 <body>
   <div class="page">
-    <a href="../" class="back-link"><span class="arrow">&larr;</span> Back to Portfolio</a>
 
     <!-- ── HERO ── -->
     <section class="hero">

--- a/gumball/index.html
+++ b/gumball/index.html
@@ -486,7 +486,6 @@
 </head>
 <body>
 <div class="page">
-  <a href="../" class="back-link"><span class="arrow">&larr;</span> All Projects</a>
 
   <header class="hero">
     <span class="hero-emoji">🍬</span>

--- a/hyperfit/index.html
+++ b/hyperfit/index.html
@@ -561,8 +561,6 @@
     </filter>
   </svg>
 
-  <a href="../" class="back-link">&larr; All Projects</a>
-
   <!-- ─── HERO ─── -->
   <section class="hero">
     <p class="hero-eyebrow">Now in TestFlight Beta</p>

--- a/index.html
+++ b/index.html
@@ -952,7 +952,7 @@
           <div class="exhibit-number">Exhibit 01</div>
           <h2 class="exhibit-title">CORTIS</h2>
           <div class="exhibit-type">Context Intelligence Platform</div>
-          <a href="cortis/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="cortis/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
         </div>
 
         <div class="exhibit-content">
@@ -1028,7 +1028,7 @@
           <div class="exhibit-number">Exhibit 02</div>
           <h2 class="exhibit-title">Broadside</h2>
           <div class="exhibit-type">Social Media Composer</div>
-          <a href="broadside/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="broadside/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
           <div class="store-links">
             <!-- Replace # with actual store URLs when available -->
             <a href="#" class="store-link coming-soon">
@@ -1049,7 +1049,7 @@
           <p class="exhibit-summary">
             Compose a post once, customize per platform, and dispatch to Twitter, LinkedIn, Reddit,
             Instagram, WhatsApp, and Facebook at once &mdash; with a vintage writing-desk aesthetic.
-            <a href="broadside/">&rarr; Details</a>
+            <a href="broadside/" target="_blank" rel="noopener">&rarr; Details</a>
           </p>
 
           <p class="exhibit-story">
@@ -1164,7 +1164,7 @@
           <div class="exhibit-number">Exhibit 03</div>
           <h2 class="exhibit-title">System Design Arcade</h2>
           <div class="exhibit-type">Interactive Learning Game</div>
-          <a href="system-design-arcade/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="system-design-arcade/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
           <div class="store-links">
             <a href="https://apps.apple.com/us/app/system-design-arcade/id6759821733" class="store-link">
               <span class="store-icon">&#63743;</span> App Store
@@ -1181,7 +1181,7 @@
           <p class="exhibit-summary">
             Master system design concepts through interactive, arcade-style mobile games.
             Learn caching, sharding, load balancing, and more &mdash; by playing.
-            <a href="system-design-arcade/">&rarr; Details</a>
+            <a href="system-design-arcade/" target="_blank" rel="noopener">&rarr; Details</a>
           </p>
 
           <p class="exhibit-story">
@@ -1276,7 +1276,7 @@
           <div class="exhibit-number">Exhibit 04</div>
           <h2 class="exhibit-title">TossUp</h2>
           <div class="exhibit-type">Cricket Auction &amp; Club Platform</div>
-          <a href="tossup/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="tossup/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
           <div class="store-links">
             <!-- Replace # with actual URL when available -->
             <a href="#" class="store-link coming-soon">
@@ -1291,7 +1291,7 @@
           <p class="exhibit-summary">
             Run professional-grade cricket auctions with real-time bidding, dual auction models,
             role-based live views, club management, and tournament hosting.
-            <a href="tossup/">&rarr; Details</a>
+            <a href="tossup/" target="_blank" rel="noopener">&rarr; Details</a>
           </p>
 
           <p class="exhibit-story">
@@ -1412,7 +1412,7 @@
           <div class="exhibit-number">Exhibit 05</div>
           <h2 class="exhibit-title">Koo</h2>
           <div class="exhibit-type">Baby Tracking &amp; Parenting Companion</div>
-          <a href="koo/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="koo/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
           <div class="store-links">
             <a href="#" class="store-link coming-soon">
               <span class="store-icon">&#63743;</span> App Store &mdash; Soon
@@ -1429,7 +1429,7 @@
           <p class="exhibit-summary">
             Track feeding, sleep, diapers, and milestones with voice logging, WHO growth percentiles,
             and collaborative caregiving through real-time family sync.
-            <a href="koo/">&rarr; Details</a>
+            <a href="koo/" target="_blank" rel="noopener">&rarr; Details</a>
           </p>
 
           <p class="exhibit-story">
@@ -1543,7 +1543,7 @@
           <div class="exhibit-number">Exhibit 06</div>
           <h2 class="exhibit-title">Zeroshot</h2>
           <div class="exhibit-type">Gamified Python &amp; AI/ML Learning</div>
-          <a href="zeroshot/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="zeroshot/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
         </div>
 
         <div class="exhibit-content">
@@ -1624,7 +1624,7 @@
           <div class="exhibit-number">Exhibit 07</div>
           <h2 class="exhibit-title">Gumball</h2>
           <div class="exhibit-type">AI Agent Builder</div>
-          <a href="gumball/" class="exhibit-link">Project details <span class="arrow">&rarr;</span></a>
+          <a href="gumball/" class="exhibit-link" target="_blank" rel="noopener">Project details <span class="arrow">&rarr;</span></a>
         </div>
 
         <div class="exhibit-content">
@@ -1701,7 +1701,7 @@
           <div class="exhibit-number">Exhibit 08</div>
           <h2 class="exhibit-title">HyperFit</h2>
           <div class="exhibit-type">Strength Training OS</div>
-          <a href="hyperfit/" class="exhibit-link">Project details &amp; TestFlight <span class="arrow">&rarr;</span></a>
+          <a href="hyperfit/" class="exhibit-link" target="_blank" rel="noopener">Project details &amp; TestFlight <span class="arrow">&rarr;</span></a>
           <div class="store-links">
             <a href="https://testflight.apple.com/join/jwQZDmDc" class="store-link" target="_blank" rel="noopener">
               <span class="store-icon">&#63743;</span> TestFlight Beta
@@ -1718,7 +1718,7 @@
           <p class="exhibit-summary">
             An honest mirror for strength training &mdash; recruitment-weighted muscle heatmap,
             share-ready session cards, PR detection. No streaks, no gamified noise.
-            <a href="hyperfit/">&rarr; Details &amp; TestFlight</a>
+            <a href="hyperfit/" target="_blank" rel="noopener">&rarr; Details &amp; TestFlight</a>
           </p>
 
           <p class="exhibit-story">
@@ -1828,7 +1828,7 @@
             <a href="https://github.com/harshssd/brevn" class="store-link" target="_blank" rel="noopener">
               <span class="store-icon">&lt;/&gt;</span> Source Code
             </a>
-            <a href="brevn/" class="store-link">
+            <a href="brevn/" class="store-link" target="_blank" rel="noopener">
               <span class="store-icon">&#x2197;</span> Details &amp; v0.2 features
             </a>
           </div>

--- a/koo/index.html
+++ b/koo/index.html
@@ -578,7 +578,6 @@
 
   <!-- ─── HERO ─── -->
   <section class="hero">
-    <a href="../" class="back-link">&larr; Hyperfocused Engineer</a>
 
     <div class="hero-icon"><span>&#128118;</span></div>
     <h1 class="hero-title">Koo</h1>

--- a/system-design-arcade/index.html
+++ b/system-design-arcade/index.html
@@ -536,7 +536,7 @@
   <!-- ───────── Top nav ───────── -->
   <nav class="topnav">
     <div class="topnav-inner">
-      <a href="https://hyperfocusedengineer.github.io/" class="brand" aria-label="Hyperfocused Engineer home">← HFE</a>
+      <span class="brand">HFE</span>
       <a href="#download" class="nav-cta">Get the app</a>
       <a href="#download" class="nav-cta nav-cta-mobile">Download</a>
     </div>

--- a/tossup/index.html
+++ b/tossup/index.html
@@ -672,7 +672,6 @@
 
     <!-- ─── HERO ─── -->
     <section class="hero">
-      <a href="../" class="back-link">&larr; Hyperfocused Engineer</a>
 
       <div class="hero-icon"><span>&#127951;</span></div>
       <h1 class="hero-title">TossUp</h1>

--- a/zeroshot/index.html
+++ b/zeroshot/index.html
@@ -540,7 +540,6 @@
 </head>
 <body>
   <div class="page">
-    <a href="../" class="back-link"><span class="arrow">&larr;</span> Back to Portfolio</a>
 
     <!-- ── HERO ── -->
     <section class="hero">


### PR DESCRIPTION
## Summary
- Make every product-detail link on the home page open in a new tab (`target="_blank" rel="noopener"`) — 13 links total (`exhibit-link` "Project details →" plus the secondary "→ Details" links).
- Remove the prominent top back-link to the home page from each product/detail page so it's no longer an easy, visible path back: broadside, cortis, gumball, hyperfit, koo, tossup, zeroshot, brevn-essay. For system-design-arcade the back-link is the topnav brand, so it's converted to a non-clickable `HFE` label to preserve the nav layout.
- Footer credit links back to home (e.g. "Built by Hyperfocused Engineer", "More from HFE") are intentionally left intact per request.

## Test plan
- [ ] Home page detail links open the product page in a new tab.
- [ ] No visible top "← Hyperfocused Engineer / Back to Portfolio / All Projects" link on product pages.
- [ ] Footer credit links still present and clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)