### PR TITLE
brevn: patch in real TestFlight public link

### DIFF
--- a/brevn/index.html
+++ b/brevn/index.html
@@ -432,7 +432,7 @@
     // page is shippable. Update the href in this script when ASC issues the
     // public URL (typically ~24h after first external-distribution submit).
     (function() {
-      var TF_URL = 'TESTFLIGHT_URL_PLACEHOLDER';
+      var TF_URL = 'https://testflight.apple.com/join/zW2VEqc5';
       if (TF_URL !== 'TESTFLIGHT_' + 'URL_PLACEHOLDER') {
         document.getElementById('cta-tf').href = TF_URL;
         document.getElementById('tf-link').href = TF_URL;

--- a/index.html
+++ b/index.html
@@ -1820,9 +1820,9 @@
           <div class="exhibit-number">Exhibit 09</div>
           <h2 class="exhibit-title">Brevn</h2>
           <div class="exhibit-type">Focus you can measure</div>
-          <a href="https://testflight.apple.com/join/TT9p26gF" class="exhibit-link" target="_blank" rel="noopener">Public TestFlight <span class="arrow">&rarr;</span></a>
+          <a href="https://testflight.apple.com/join/zW2VEqc5" class="exhibit-link" target="_blank" rel="noopener">Public TestFlight <span class="arrow">&rarr;</span></a>
           <div class="store-links">
-            <a href="https://testflight.apple.com/join/TT9p26gF" class="store-link" target="_blank" rel="noopener">
+            <a href="https://testflight.apple.com/join/zW2VEqc5" class="store-link" target="_blank" rel="noopener">
               <span class="store-icon">&#63743;</span> TestFlight Beta
             </a>
             <a href="https://github.com/harshssd/brevn" class="store-link" target="_blank" rel="noopener">


### PR DESCRIPTION
v0.2.0 uploaded, submitted for Beta App Review. Public link `zW2VEqc5` is live now; survives the review once Apple approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)