### PR TITLE
sda: add Google Ads tag (AW-972530047)

### DIFF
--- a/system-design-arcade/index.html
+++ b/system-design-arcade/index.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-972530047"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'AW-972530047');
+  </script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#06060F">


### PR DESCRIPTION
Adds the Google tag (gtag.js) for Google Ads account AW-972530047 to the System Design Arcade landing page, placed immediately after `<head>` as Google's setup instructions specify.

Scope: only `system-design-arcade/index.html`. Not added to the privacy policy page or other product pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)