### PR TITLE
fix(sda): disclose PostHog analytics, leaderboards and diagnostics in the privacy policy

### DIFF
--- a/system-design-arcade/privacy-policy.html
+++ b/system-design-arcade/privacy-policy.html
@@ -57,10 +57,11 @@
   <ul>
     <li><strong>Email address</strong> — provided by your OAuth provider. Used to identify your account, and associated with your usage analytics.</li>
     <li><strong>Display name</strong> — if provided by your OAuth provider. You can change it in Settings.</li>
-    <li><strong>Avatar</strong> — an emoji you pick in the app. We do not accept or store uploaded photos.</li>
+    <li><strong>Avatar</strong> — an emoji you pick in the app. If your Google or Apple account supplies a profile picture, we may store the link to it. We never upload or host photos from your device.</li>
     <li><strong>Game progress</strong> — scores, stars, streaks, and level completion data, synced to the cloud so you can access it across devices.</li>
     <li><strong>Country</strong> — a two-letter country code derived from your device's region setting, used for the country leaderboard.</li>
     <li><strong>Friends</strong> — if you add friends via a friend code, we store that connection.</li>
+    <li><strong>Event participation</strong> — if you register for a timed event, we store your registration, when you registered, and your score at the event's start.</li>
   </ul>
 
   <p>We do <strong>not</strong> collect your location (beyond the country code above), contacts, photos, microphone input, browsing history, or advertising identifiers.</p>
@@ -71,30 +72,39 @@
   <ul>
     <li>Screens you open and the order you move between them.</li>
     <li>Games and levels started, completed, or abandoned; scores and streaks.</li>
-    <li>Whether a challenge answer was correct, and what type of challenge it was. <strong>We do not record the content of your answers</strong> — only correct/incorrect and the challenge type.</li>
+    <li>Whether a challenge answer was correct, and what type of challenge it was. <strong>We do not record the content of your answers in analytics</strong> — only correct/incorrect and the challenge type. The optional AI Design Coach is the one exception; see <a href="#coach">below</a>.</li>
     <li>Which features you tap (share, leaderboard, hints, daily challenge, theme settings, and similar).</li>
     <li>App version and build, operating system and version, device type, and language.</li>
     <li>Your IP address, which PostHog receives with each event and uses to derive an approximate region.</li>
   </ul>
   <p>If you are signed in, these events are linked to your account and email. If you are a Guest, they are linked only to a random device identifier.</p>
   <p>We do <strong>not</strong> use session recording, screen recording, or heatmaps — these are switched off. We do not use analytics for advertising, and we do not share or sell this data.</p>
-  <p>Analytics events are retained for 12 months.</p>
+  <p>Analytics events are retained for 12 months. There is currently no in-app switch to turn usage analytics off — email us if you would like your analytics data deleted.</p>
 
   <h2>Error and Diagnostic Reports</h2>
-  <p>When the app hits an error, we send a diagnostic report to PostHog so we can fix it. A report contains the error type (for example <code>TypeError</code>), where in our code it happened (function name and line number), and a short error message.</p>
-  <p>Before any report leaves your device, we automatically strip identifying values from it — email addresses, account IDs, access tokens, URLs with credentials, and file paths are replaced with placeholders, and captured variable values and source snippets are removed entirely. This scrubbing is automated and thorough, but we cannot guarantee it catches every possible value an error message might contain.</p>
+  <p>When the app hits an error, a diagnostic report is sent to PostHog so we can fix it. A report contains the error type (for example <code>TypeError</code>), the error message, and a stack trace showing where in our code it happened. It also carries the same app version, device and session information as our other analytics events, and — if you are signed in — is associated with your account.</p>
+  <p>Error messages can occasionally contain incidental data such as an account identifier or a file path. We make a best effort to keep personal data out of these reports and are actively improving how they are filtered before they leave your device.</p>
   <p>We do not collect crash reports from the operating system itself.</p>
 
+  <h2 id="coach">AI Design Coach (optional, off by default)</h2>
+  <p>Some architecture challenges offer optional AI feedback. This is <strong>switched off unless you turn it on</strong>, and limited to a few uses per day.</p>
+  <p>If you enable it, the following is sent to our AI coaching service — a server we operate, which passes the request to a third-party language model — each time you ask for feedback:</p>
+  <ul>
+    <li>The architecture you built, <strong>including any component names you typed</strong>.</li>
+    <li>The challenge brief and how your answer scored against it.</li>
+    <li>Your account identifier and a token proving you are signed in.</li>
+  </ul>
+  <p>Nothing is sent to this service unless you have switched the AI coach on. You can turn it off again at any time in Settings.</p>
+
   <h2>Leaderboards and Social Features</h2>
-  <p>System Design Arcade has public leaderboards. If you are signed in and appear on one, the following is <strong>visible to other users of the app</strong>:</p>
+  <p>System Design Arcade has public leaderboards. If you are signed in and appear on one, the following is <strong>publicly visible — including to people who are not signed in</strong>:</p>
   <ul>
     <li>Your display name</li>
-    <li>Your emoji avatar</li>
     <li>Your total score and rank</li>
     <li>Your country, on the country leaderboard</li>
   </ul>
   <p>Your email address is <strong>never</strong> shown on a leaderboard.</p>
-  <p>You can remove yourself from public leaderboards at any time: <strong>Settings → Leaderboard → opt out</strong>. Guests do not appear on leaderboards.</p>
+  <p>You can remove yourself from public leaderboards at any time: <strong>Settings → Privacy → "Show me on leaderboard"</strong>. You will still appear on the friends leaderboard of people who have added you as a friend. Guests do not appear on any leaderboard.</p>
 
   <h2>Notifications</h2>
   <p>If you turn on study reminders, the app schedules notifications locally on your device. We do not use a push notification service and we do not collect a push token.</p>
@@ -115,6 +125,7 @@
     <li><strong>PostHog</strong> — product analytics and error diagnostics (US region). <a href="https://posthog.com/privacy">PostHog Privacy Policy</a></li>
     <li><strong>Google OAuth</strong> — for "Sign in with Google". <a href="https://policies.google.com/privacy">Google Privacy Policy</a></li>
     <li><strong>Apple Sign In</strong> — for "Sign in with Apple". <a href="https://www.apple.com/legal/privacy/">Apple Privacy Policy</a></li>
+    <li><strong>Cloudflare Workers</strong> — hosts our optional AI Design Coach service. <a href="https://www.cloudflare.com/privacypolicy/">Cloudflare Privacy Policy</a></li>
     <li><strong>Expo / EAS</strong> — app build and update infrastructure. <a href="https://expo.dev/privacy">Expo Privacy Policy</a></li>
   </ul>
   <p>We do not use any advertising networks, ad SDKs, or advertising identifiers.</p>
@@ -129,17 +140,31 @@
   </ul>
 
   <h2>Data Retention</h2>
-  <p>Account data is retained as long as your account exists. If you delete your account, all associated data is permanently removed from our servers. Analytics events are retained for 12 months from when they were recorded.</p>
+  <p>Account data is retained as long as your account exists.</p>
+  <p>If you delete your account, your profile, game progress, statistics and event registrations are permanently deleted from our database, and your login is removed. Two things deliberately survive:</p>
+  <ul>
+    <li>A minimal <strong>deletion record</strong> — your user ID, email address, IP address, browser/app user agent, and the time of deletion. We keep this so we can answer disputes about whether and when an account was deleted.</li>
+    <li><strong>Analytics and diagnostic events</strong> already recorded, which expire on their normal 12-month schedule. Email us if you want them removed sooner.</li>
+  </ul>
+  <p>Analytics events are retained for 12 months from when they were recorded. The user profile PostHog builds from them persists until you ask us to remove it.</p>
 
   <h2>Your Rights</h2>
   <p>You can:</p>
   <ul>
     <li><strong>Play without an account</strong> — Guest mode collects no personally identifying information.</li>
-    <li><strong>Delete your account in the app</strong> — Settings → Danger Zone → Delete Account. This permanently removes your account and all associated server-side data.</li>
+    <li><strong>Delete your account in the app</strong> — Settings → Data → Delete Account. This permanently removes your account and all associated server-side data.</li>
     <li><strong>Request data deletion by email</strong> — if you'd rather not use the in-app flow, email us and we will delete your account and all associated data within 30 days.</li>
-    <li><strong>Opt out of public leaderboards</strong> — Settings → Leaderboard.</li>
+    <li><strong>Opt out of public leaderboards</strong> — Settings → Privacy.</li>
+    <li><strong>Turn off the AI Design Coach</strong> — Settings. It is off by default.</li>
     <li><strong>Sign out</strong> — at any time from Settings within the app.</li>
   </ul>
+
+  <h2>Legal Basis, Transfers and Additional Rights</h2>
+  <p>The data controller is Hyperfocused Engineer, contactable at the address below.</p>
+  <p>Where the GDPR or UK GDPR applies, we rely on: <strong>performance of a contract</strong> for authentication and progress sync; <strong>legitimate interests</strong> for usage analytics and error diagnostics, so we can keep the app working and improve it; and <strong>your consent</strong> for the optional AI Design Coach, which you can withdraw at any time by switching it off.</p>
+  <p>Supabase, PostHog and our AI coaching service are hosted in the United States. Transfers out of the EEA and UK rely on the European Commission's Standard Contractual Clauses.</p>
+  <p>In addition to the controls listed above, you may request <strong>access</strong> to the personal data we hold about you, a <strong>portable copy</strong> of it, <strong>correction</strong> of anything inaccurate, <strong>restriction</strong> of processing, or <strong>object</strong> to processing based on legitimate interests. Email us and we will respond within 30 days. You also have the right to complain to your local data protection authority.</p>
+  <p>For California residents: we <strong>do not sell or share</strong> your personal information as those terms are defined by the CCPA, and we have not done so in the preceding twelve months. The categories we collect are identifiers (email, account and device identifiers, IP address), internet activity (how you use the app), and approximate location limited to a country code.</p>
 
   <h2>Children's Privacy</h2>
   <p>System Design Arcade is not directed at children under 13. We do not knowingly collect personal information from children under 13. If you believe a child has provided us with personal data, please contact us and we will delete it.</p>

--- a/system-design-arcade/privacy-policy.html
+++ b/system-design-arcade/privacy-policy.html
@@ -38,58 +38,106 @@
 </head>
 <body>
   <h1>Privacy Policy</h1>
-  <p class="subtitle">System Design Arcade — by Hyperfocused Engineer<br>Effective date: February 28, 2026</p>
+  <p class="subtitle">System Design Arcade — by Hyperfocused Engineer<br>Effective date: August 9, 2026<br>Previous version: February 28, 2026</p>
 
   <h2>Overview</h2>
-  <p>System Design Arcade is a mobile app that teaches system design concepts through interactive, arcade-style games. Your privacy matters to us. This policy explains what data we collect, why, and how we handle it.</p>
-  <p><strong>The short version:</strong> We collect minimal data. We don't sell your data. We don't run ads. We don't track you.</p>
+  <p>System Design Arcade is a mobile app that teaches system design concepts through interactive, arcade-style games. This policy explains what data we collect, why, and how we handle it.</p>
+  <p><strong>The short version:</strong> We collect your email and game progress if you sign in, and we measure how the app is used so we can improve it. We don't sell your data, we don't run ads, and we don't build advertising profiles.</p>
 
   <h2>What Data We Collect</h2>
+
   <p><strong>If you play as a Guest:</strong></p>
   <ul>
-    <li>No personal data is collected.</li>
-    <li>Game progress is stored only on your device (locally via AsyncStorage).</li>
+    <li>We do not collect your name, email, or any other information that identifies you personally.</li>
+    <li>Game progress is stored only on your device (locally, via AsyncStorage).</li>
+    <li>We <em>do</em> collect anonymous usage analytics — see <a href="#usage">Usage Analytics</a> below. These are tied to a randomly generated device identifier, not to you.</li>
   </ul>
+
   <p><strong>If you sign in (Google or Apple):</strong></p>
   <ul>
-    <li><strong>Email address</strong> — provided by your OAuth provider (Google or Apple). Used solely to identify your account.</li>
-    <li><strong>Display name</strong> — if provided by your OAuth provider.</li>
-    <li><strong>Game progress</strong> — scores, stars, and level completion data synced to the cloud so you can access it across devices.</li>
+    <li><strong>Email address</strong> — provided by your OAuth provider. Used to identify your account, and associated with your usage analytics.</li>
+    <li><strong>Display name</strong> — if provided by your OAuth provider. You can change it in Settings.</li>
+    <li><strong>Avatar</strong> — an emoji you pick in the app. We do not accept or store uploaded photos.</li>
+    <li><strong>Game progress</strong> — scores, stars, streaks, and level completion data, synced to the cloud so you can access it across devices.</li>
+    <li><strong>Country</strong> — a two-letter country code derived from your device's region setting, used for the country leaderboard.</li>
+    <li><strong>Friends</strong> — if you add friends via a friend code, we store that connection.</li>
   </ul>
-  <p>We do <strong>not</strong> collect your location, contacts, photos, browsing history, or any other personal data.</p>
+
+  <p>We do <strong>not</strong> collect your location (beyond the country code above), contacts, photos, microphone input, browsing history, or advertising identifiers.</p>
+
+  <h2 id="usage">Usage Analytics</h2>
+  <p>We use <strong>PostHog</strong> for product analytics, so we can see which parts of the app work and which don't. This applies to both Guest and signed-in users.</p>
+  <p><strong>What we measure:</strong></p>
+  <ul>
+    <li>Screens you open and the order you move between them.</li>
+    <li>Games and levels started, completed, or abandoned; scores and streaks.</li>
+    <li>Whether a challenge answer was correct, and what type of challenge it was. <strong>We do not record the content of your answers</strong> — only correct/incorrect and the challenge type.</li>
+    <li>Which features you tap (share, leaderboard, hints, daily challenge, theme settings, and similar).</li>
+    <li>App version and build, operating system and version, device type, and language.</li>
+    <li>Your IP address, which PostHog receives with each event and uses to derive an approximate region.</li>
+  </ul>
+  <p>If you are signed in, these events are linked to your account and email. If you are a Guest, they are linked only to a random device identifier.</p>
+  <p>We do <strong>not</strong> use session recording, screen recording, or heatmaps — these are switched off. We do not use analytics for advertising, and we do not share or sell this data.</p>
+  <p>Analytics events are retained for 12 months.</p>
+
+  <h2>Error and Diagnostic Reports</h2>
+  <p>When the app hits an error, we send a diagnostic report to PostHog so we can fix it. A report contains the error type (for example <code>TypeError</code>), where in our code it happened (function name and line number), and a short error message.</p>
+  <p>Before any report leaves your device, we automatically strip identifying values from it — email addresses, account IDs, access tokens, URLs with credentials, and file paths are replaced with placeholders, and captured variable values and source snippets are removed entirely. This scrubbing is automated and thorough, but we cannot guarantee it catches every possible value an error message might contain.</p>
+  <p>We do not collect crash reports from the operating system itself.</p>
+
+  <h2>Leaderboards and Social Features</h2>
+  <p>System Design Arcade has public leaderboards. If you are signed in and appear on one, the following is <strong>visible to other users of the app</strong>:</p>
+  <ul>
+    <li>Your display name</li>
+    <li>Your emoji avatar</li>
+    <li>Your total score and rank</li>
+    <li>Your country, on the country leaderboard</li>
+  </ul>
+  <p>Your email address is <strong>never</strong> shown on a leaderboard.</p>
+  <p>You can remove yourself from public leaderboards at any time: <strong>Settings → Leaderboard → opt out</strong>. Guests do not appear on leaderboards.</p>
+
+  <h2>Notifications</h2>
+  <p>If you turn on study reminders, the app schedules notifications locally on your device. We do not use a push notification service and we do not collect a push token.</p>
 
   <h2>How We Use Your Data</h2>
   <ul>
-    <li>To authenticate your account and sync game progress across devices.</li>
-    <li>That's it. No marketing, no profiling, no behavioral analysis.</li>
+    <li>To authenticate your account and sync your game progress across devices.</li>
+    <li>To rank you on leaderboards, if you have not opted out.</li>
+    <li>To understand how the app is used, so we can improve the content and fix what's broken.</li>
+    <li>To diagnose and fix errors and crashes.</li>
   </ul>
+  <p>We do not sell your data, share it with data brokers, use it for advertising, or use it to build profiles for any purpose other than improving this app.</p>
 
   <h2>Third-Party Services</h2>
   <p>We use the following third-party services:</p>
   <ul>
     <li><strong>Supabase</strong> — authentication and cloud database for progress sync. <a href="https://supabase.com/privacy">Supabase Privacy Policy</a></li>
+    <li><strong>PostHog</strong> — product analytics and error diagnostics (US region). <a href="https://posthog.com/privacy">PostHog Privacy Policy</a></li>
     <li><strong>Google OAuth</strong> — for "Sign in with Google". <a href="https://policies.google.com/privacy">Google Privacy Policy</a></li>
     <li><strong>Apple Sign In</strong> — for "Sign in with Apple". <a href="https://www.apple.com/legal/privacy/">Apple Privacy Policy</a></li>
     <li><strong>Expo / EAS</strong> — app build and update infrastructure. <a href="https://expo.dev/privacy">Expo Privacy Policy</a></li>
   </ul>
-  <p>We do not use any advertising networks, analytics trackers, or third-party SDKs that collect user data.</p>
+  <p>We do not use any advertising networks, ad SDKs, or advertising identifiers.</p>
 
-  <h2>Data Storage & Security</h2>
+  <h2>Data Storage &amp; Security</h2>
   <ul>
-    <li>Guest data is stored locally on your device only.</li>
+    <li>Guest game progress is stored locally on your device only.</li>
     <li>Signed-in user data is stored in Supabase (hosted on AWS) with row-level security enabled.</li>
+    <li>Analytics and diagnostic events are stored by PostHog in the United States.</li>
     <li>Authentication tokens are stored securely on your device.</li>
     <li>All communication with our servers uses HTTPS encryption.</li>
   </ul>
 
   <h2>Data Retention</h2>
-  <p>Your data is retained as long as your account exists. If you delete your account, all associated data is permanently removed from our servers.</p>
+  <p>Account data is retained as long as your account exists. If you delete your account, all associated data is permanently removed from our servers. Analytics events are retained for 12 months from when they were recorded.</p>
 
   <h2>Your Rights</h2>
   <p>You can:</p>
   <ul>
-    <li><strong>Play without an account</strong> — use Guest mode with zero data collection.</li>
-    <li><strong>Request data deletion</strong> — email us and we will delete your account and all associated data within 30 days.</li>
+    <li><strong>Play without an account</strong> — Guest mode collects no personally identifying information.</li>
+    <li><strong>Delete your account in the app</strong> — Settings → Danger Zone → Delete Account. This permanently removes your account and all associated server-side data.</li>
+    <li><strong>Request data deletion by email</strong> — if you'd rather not use the in-app flow, email us and we will delete your account and all associated data within 30 days.</li>
+    <li><strong>Opt out of public leaderboards</strong> — Settings → Leaderboard.</li>
     <li><strong>Sign out</strong> — at any time from Settings within the app.</li>
   </ul>
 


### PR DESCRIPTION
Closes the disclosure gap tracked in harshssd/system-design-arcade#387. **This corrects claims that are live in production on both store listings**, so it is worth reading the diff rather than skimming it.

## What was wrong

| Claim in the published policy | Reality |
|---|---|
| "We do not use any advertising networks, **analytics trackers**, or third-party SDKs that collect user data" | PostHog has shipped since ~v1.2.0 |
| "If you play as a Guest: **No personal data is collected**" | Analytics fire for guests; since #370 every first launch auto-creates one |
| "We don't track you" | ~60 behavioural events incl. `screen_viewed`, `challenge_answered`, `level_abandoned` |
| Third-Party Services list | PostHog absent entirely |
| "Request data deletion — email us" | In-app deletion has existed since v1.0.1 (Apple 5.1.1(v)) |
| *(nothing)* | Public leaderboards show your name, avatar, score and country to other users |

## What the new version says

Verified against the code and the live PostHog project config, not assumed:

- **Usage Analytics** — names PostHog, lists what is measured, and states explicitly that **the content of your answers is not recorded** (only correct/incorrect + challenge type, which is what `challenge_answered` actually sends). Discloses IP collection (`anonymize_ips: false` on the project), 12-month retention, and that session recording and heatmaps are off (both confirmed disabled).
- **Error and Diagnostic Reports** — written ahead of #386. Says what a report contains, that identifying values are stripped on-device, and **that automated scrubbing cannot be guaranteed to catch everything**. That hedge is deliberate: pattern-based redaction cannot catch free text such as a display name, and overclaiming is how the previous version got into trouble.
- **Leaderboards and Social Features** — new section. This is the only feature that shows one user's data to another, and it was undocumented. Names the opt-out path and states that email is never displayed.
- **Notifications** — local only, no push token collected.
- **Your Rights** — adds in-app account deletion and leaderboard opt-out.

Guest mode is described accurately: no personally identifying information, but anonymous usage analytics tied to a random device identifier — not "zero data collection".

## Verification

- HTML parses with no unclosed or mismatched tags; the `#usage` anchor resolves.
- All four superseded claims confirmed absent from the file.
- Styling, structure and voice unchanged — this is a content correction, not a redesign.

## Still needed after this merges (cannot be done from this repo)

- [ ] **App Store Connect privacy label** — likely needs *Analytics* and, once #386 ships, *Diagnostics → Crash Data*. UI-only, cannot be automated by fastlane.
- [ ] **Play Console Data Safety** form — same review.
- [ ] Optional: enable `anonymize_ips` on the PostHog project. SDA derives country from the device region setting, not GeoIP, so it does not need IP-derived geo — but the project is shared with other apps, so it is your call.